### PR TITLE
Add ForegroundService type as "Connected Device"

### DIFF
--- a/Laerdal.Dfu/Platforms/Android/Specific/DfuService.cs
+++ b/Laerdal.Dfu/Platforms/Android/Specific/DfuService.cs
@@ -1,11 +1,11 @@
 using Android.App;
-
+using Android.Content.PM;
 using Java.Lang;
 
 namespace Laerdal.Dfu.Specific
 {
     
-    [Service]
+    [Service (ForegroundServiceType = ForegroundService.TypeConnectedDevice)]
     public class DfuService : Laerdal.Dfu.Bindings.Android.DfuBaseService
     {
         public DfuService()


### PR DESCRIPTION
**What went wrong:**
- Got exception on MAUI Android 14:  android.app.MissingForegroundServiceTypeException: Starting FGS without a type
- See issue: #54 

**What was done:**
- Added Foreground service type as "Connected Device" on service attribute to be injected into Android Manifest as seen in: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/423#issuecomment-1845268831

**How was it tested:**
- Targeted Android 14 sdk
- Added permissions to manifest:
```
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
```
- Attempted DFU again, did not get crash. ~~Still facing other issues on my end though~~

Please feel free to edit, comment or reject the PR, very possible that I'm misunderstanding something. Any feedback welcome.