### PR TITLE
[MAN-456] resupport iossimulator side builds

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -26,7 +26,7 @@ env:
   SCL_DEPENDENCY_TRACKER_SERVER_URL: ${{          secrets.SCL_DEPENDENCY_TRACKER_SERVER_URL          }}
   SCL_DEPENDENCY_TRACKER_SIGNING_PRIVATE_KEY: ${{ secrets.SCL_DEPENDENCY_TRACKER_SIGNING_PRIVATE_KEY }}
 
-  DOTNET_TARGET_WORKLOAD_VERSION: "8.0.402" # dont upgrade this lightheartedly   the workload snapshot implicitly defines which versions of Android/iOS/MacCatalyst SDKs are supported
+  DOTNET_TARGET_WORKLOAD_VERSION: "8.0.405" # dont upgrade this lightheartedly   the workload snapshot implicitly defines which versions of Android/iOS/MacCatalyst SDKs are supported
 
 
 on:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -16,9 +16,10 @@ env:
   LAERDAL_REPOSITORY_PATH: ${{         github.repository                     }}
 
   # note that its vital that we use our own token here instead of GITHUB_TOKEN    that is because access the
-  # nuget repos of Laerdal.Dfu.Bindings.iOS and Laerdal.Dfu.Bindings.Android which are inaccessible to the GITHUB_TOKEN 
-  SCL_GITHUB_ACCESS_TOKEN: ${{        secrets.SCL_GITHUB_ACCESS_TOKEN        }}
+  # nuget repos of Laerdal.Dfu.Bindings.iOS and Laerdal.Dfu.Bindings.Android which are inaccessible to the GITHUB_TOKEN
   SCL_NUGET_ORG_FEED_API_KEY: ${{     secrets.NUGET_ORG_FEED_API_KEY         }}
+
+  SCL_GITHUB_ACCESS_TOKEN: ${{        secrets.SCL_GITHUB_ACCESS_TOKEN        }}
   SCL_GITHUB_NUGET_FEED_USERNAME: ${{ secrets.SCL_GITHUB_NUGET_FEED_USERNAME }}
 
   SCL_DEPENDENCY_TRACKER_API_KEY: ${{             secrets.SCL_DEPENDENCY_TRACKER_API_KEY             }}
@@ -55,7 +56,9 @@ jobs:
         with:
           fetch-tags: true # https://github.com/actions/checkout/issues/1471#issuecomment-1771231294
           fetch-depth: 0
-
+  
+      #  "${{ github.actor }}"
+      #  "${{ github.token }}"
       - name: '🛠 Setup Build Environment'
         shell: 'bash'
         run: |
@@ -64,8 +67,8 @@ jobs:
                      "${{env.BUILD_REPOSITORY_FOLDERPATH}}/Laerdal.Scripts/Laerdal.SetupBuildEnvironment.sh"     \
                              "${{env.DOTNET_TARGET_WORKLOAD_VERSION}}"                                           \
                              "https://nuget.pkg.github.com/Laerdal/index.json"                                   \
-                             "${{ github.actor                       }}"                                         \
-                             "${{ github.token                       }}"                                         \
+                             "${{ env.SCL_GITHUB_NUGET_FEED_USERNAME }}"                                         \
+                             "${{ env.SCL_GITHUB_ACCESS_TOKEN        }}"                                         \
                              "${{ env.BUILD_REPOSITORY_FOLDERPATH    }}/Artifacts"
 
       # we need to manually install java11 because it is needed by the latest windows vm-images that run on

--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -11,12 +11,11 @@
     </PropertyGroup>
 
     <!-- ==================== TARGET FRAMEWORKS GROUP ===================== -->
-    <PropertyGroup>       
+    <PropertyGroup>
+        <TargetFrameworks>$(TargetFrameworks)net8.0;</TargetFrameworks>
         <TargetFrameworks>$(TargetFrameworks)net8.0-ios;</TargetFrameworks>
-
-        <TargetFrameworks Condition=" '$(iOSMode)' == 'vanilla' or '$(iOSMode)' == '' ">$(TargetFrameworks)net8.0;</TargetFrameworks>
-        <TargetFrameworks Condition=" '$(iOSMode)' == 'vanilla' or '$(iOSMode)' == '' ">$(TargetFrameworks)net8.0-android;</TargetFrameworks>
-        <TargetFrameworks Condition=" '$(iOSMode)' == 'vanilla' or '$(iOSMode)' == '' ">$(TargetFrameworks)net8.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>$(TargetFrameworks)net8.0-android;</TargetFrameworks>
+        <TargetFrameworks>$(TargetFrameworks)net8.0-maccatalyst</TargetFrameworks>
     </PropertyGroup>
 
     <!-- =================== TARGET FRAMEWORK DETECTION ===================== -->
@@ -78,9 +77,6 @@
 
     <PropertyGroup>
         <Laerdal_Package_Name>Laerdal.Dfu</Laerdal_Package_Name>
-        <Laerdal_Package_Name Condition=" '$(iOSMode)' == 'simulator-x64'   ">Laerdal.Dfu.iOSSimulator.x64</Laerdal_Package_Name>
-        <Laerdal_Package_Name Condition=" '$(iOSMode)' == 'simulator-arm64' ">Laerdal.Dfu.iOSSimulator.Arm64</Laerdal_Package_Name>
-
         <Laerdal_Package_Tags>Ble;Tools;Dfu;Bluetooth;Nordic;Semiconductor;iOS;Android</Laerdal_Package_Tags>
         <Laerdal_Package_Copyright>Laerdal Medical, Francois Raminosona</Laerdal_Package_Copyright>
         <Laerdal_Package_Description>Wrapper around Nordic.Dfu</Laerdal_Package_Description>
@@ -103,17 +99,13 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Laerdal.Dfu.Bindings.Android" Version="2.7.0.43895"/>
     </ItemGroup>
-
     <!-- iOS -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-        <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.15.3.43990" Condition=" '$(iOSMode)' == '' or '$(iOSMode)' == 'vanilla' " />
-        <PackageReference Include="Laerdal.Dfu.Bindings.iOSSimulator.x64" Version="4.15.3.43990" Condition=" '$(iOSMode)' == 'simulator-x64' " />
-        <PackageReference Include="Laerdal.Dfu.Bindings.iOSSimulator.Arm64" Version="4.15.3.43990" Condition=" '$(iOSMode)' == 'simulator-arm64' " />
+        <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.15.3.43995" />
     </ItemGroup>
-
     <!-- MacCatalyst -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">
-        <PackageReference Include="Laerdal.Dfu.Bindings.MacCatalyst" Version="4.15.3.43990" />
+        <PackageReference Include="Laerdal.Dfu.Bindings.MacCatalyst" Version="4.15.3.43995" />
     </ItemGroup>
     <!-- =========================== PACKAGES ============================ -->
 

--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -38,13 +38,13 @@
         <TargetPlatformMinVersion Condition="    '$(IsForAndroid)'      == 'true' ">21.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="  '$(IsForAndroid)'      == 'true' ">21.0</SupportedOSPlatformVersion>
 
-        <!-- ios   you will need specific workloads though    dotnet workload install maui -/-version 8.0.402   -->
-        <TargetPlatformVersion Condition="       '$(IsForIOS)'          == 'true' ">17.0</TargetPlatformVersion>
+        <!-- ios   you will need specific workloads though    dotnet workload install maui -/-version 8.0.405   -->
+        <TargetPlatformVersion Condition="       '$(IsForIOS)'          == 'true' ">18.0</TargetPlatformVersion>
         <TargetPlatformMinVersion Condition="    '$(IsForIOS)'          == 'true' ">14.2</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="  '$(IsForIOS)'          == 'true' ">14.2</SupportedOSPlatformVersion>
 
-        <!-- maccatalyst   you will need specific workloads though    dotnet workload install maui -/-version 8.0.402   -->
-        <TargetPlatformVersion Condition="       '$(IsForMacCatalyst)'  == 'true' ">17.0</TargetPlatformVersion>
+        <!-- maccatalyst   you will need specific workloads though    dotnet workload install maui -/-version 8.0.405   -->
+        <TargetPlatformVersion Condition="       '$(IsForMacCatalyst)'  == 'true' ">18.0</TargetPlatformVersion>
         <TargetPlatformMinVersion Condition="    '$(IsForMacCatalyst)'  == 'true' ">13.1</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="  '$(IsForMacCatalyst)'  == 'true' ">13.1</SupportedOSPlatformVersion>
     </PropertyGroup>

--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -11,11 +11,12 @@
     </PropertyGroup>
 
     <!-- ==================== TARGET FRAMEWORKS GROUP ===================== -->
-    <PropertyGroup>
-        <TargetFrameworks>$(TargetFrameworks)net8.0;</TargetFrameworks>
+    <PropertyGroup>       
         <TargetFrameworks>$(TargetFrameworks)net8.0-ios;</TargetFrameworks>
-        <TargetFrameworks>$(TargetFrameworks)net8.0-android;</TargetFrameworks>
-        <TargetFrameworks>$(TargetFrameworks)net8.0-maccatalyst</TargetFrameworks>
+
+        <TargetFrameworks Condition=" '$(iOSMode)' == 'vanilla' or '$(iOSMode)' == '' ">$(TargetFrameworks)net8.0;</TargetFrameworks>
+        <TargetFrameworks Condition=" '$(iOSMode)' == 'vanilla' or '$(iOSMode)' == '' ">$(TargetFrameworks)net8.0-android;</TargetFrameworks>
+        <TargetFrameworks Condition=" '$(iOSMode)' == 'vanilla' or '$(iOSMode)' == '' ">$(TargetFrameworks)net8.0-maccatalyst</TargetFrameworks>
     </PropertyGroup>
 
     <!-- =================== TARGET FRAMEWORK DETECTION ===================== -->
@@ -77,6 +78,9 @@
 
     <PropertyGroup>
         <Laerdal_Package_Name>Laerdal.Dfu</Laerdal_Package_Name>
+        <Laerdal_Package_Name Condition=" '$(iOSMode)' == 'simulator-x64'   ">Laerdal.Dfu.iOSSimulator.x64</Laerdal_Package_Name>
+        <Laerdal_Package_Name Condition=" '$(iOSMode)' == 'simulator-arm64' ">Laerdal.Dfu.iOSSimulator.Arm64</Laerdal_Package_Name>
+
         <Laerdal_Package_Tags>Ble;Tools;Dfu;Bluetooth;Nordic;Semiconductor;iOS;Android</Laerdal_Package_Tags>
         <Laerdal_Package_Copyright>Laerdal Medical, Francois Raminosona</Laerdal_Package_Copyright>
         <Laerdal_Package_Description>Wrapper around Nordic.Dfu</Laerdal_Package_Description>
@@ -99,13 +103,17 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
         <PackageReference Include="Laerdal.Dfu.Bindings.Android" Version="2.7.0.43895"/>
     </ItemGroup>
+
     <!-- iOS -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-      <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.15.3.43980" />
+        <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.15.3.43990" Condition=" '$(iOSMode)' == '' or '$(iOSMode)' == 'vanilla' " />
+        <PackageReference Include="Laerdal.Dfu.Bindings.iOSSimulator.x64" Version="4.15.3.43990" Condition=" '$(iOSMode)' == 'simulator-x64' " />
+        <PackageReference Include="Laerdal.Dfu.Bindings.iOSSimulator.Arm64" Version="4.15.3.43990" Condition=" '$(iOSMode)' == 'simulator-arm64' " />
     </ItemGroup>
+
     <!-- MacCatalyst -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">
-      <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.15.3.43980" />
+        <PackageReference Include="Laerdal.Dfu.Bindings.MacCatalyst" Version="4.15.3.43990" />
     </ItemGroup>
     <!-- =========================== PACKAGES ============================ -->
 

--- a/Laerdal.Dfu/Laerdal.targets
+++ b/Laerdal.Dfu/Laerdal.targets
@@ -4,11 +4,11 @@
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
+        <Deterministic>true</Deterministic>
         <IncludeSource>true</IncludeSource>
+        <ImplicitUsings>true</ImplicitUsings>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <Deterministic>true</Deterministic>
-        <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>
 
     <!-- ==================== DEFAULT CI CONFIGURATION ==================== -->
@@ -25,14 +25,15 @@
     <!-- ==================== PACKAGING ==================== -->
     <PropertyGroup>
         <!-- Laerdal_Package_Name -->
-        <Title>$(Laerdal_Package_Name)</Title>
         <PackageId>$(Laerdal_Package_Name)</PackageId>
+
+        <Title>$(Laerdal_Package_Name)</Title>
         <AssemblyName>$(Laerdal_Package_Name)</AssemblyName>
         <RootNamespace>$(Laerdal_Package_Name)</RootNamespace>
 
         <!-- Laerdal_Package_Copyright -->
-        <Authors>$(Laerdal_Package_Copyright)</Authors>
         <Owners>$(Laerdal_Package_Copyright)</Owners>
+        <Authors>$(Laerdal_Package_Copyright)</Authors>
         <Copyright>$(Laerdal_Package_Copyright)</Copyright>
 
         <!-- Laerdal_Package_Description -->
@@ -56,8 +57,8 @@
 
     <ItemGroup>
         <None Include="$(PackageIconPath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageIconPath)')" />
-        <None Include="$(PackageLicencePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageLicencePath)')" />
         <None Include="$(PackageReadMePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageReadMePath)')" />
+        <None Include="$(PackageLicencePath)" Pack="true" PackagePath="\" Condition="Exists('$(PackageLicencePath)')" />
     </ItemGroup>
 
     <!-- ==================== SOURCELINK ==================== -->
@@ -93,6 +94,8 @@
         <Message Importance="high" Text="IsForPlainNetX :         $(IsForPlainNetX)        "/>
         <Message Importance="high" Text="IsForAppleStuff :        $(IsForAppleStuff)       "/>
         <Message Importance="high" Text="IsForMacCatalyst :       $(IsForMacCatalyst)      "/>
+        <Message Importance="High" Text="                                                  "/>
+        <Message Importance="high" Text="iOSMode :                $(iOSMode)               "/>
     </Target>
 
     <!-- ==================== MAUI for .NET8 changes ==================== -->

--- a/Laerdal.Dfu/Laerdal.targets
+++ b/Laerdal.Dfu/Laerdal.targets
@@ -94,8 +94,6 @@
         <Message Importance="high" Text="IsForPlainNetX :         $(IsForPlainNetX)        "/>
         <Message Importance="high" Text="IsForAppleStuff :        $(IsForAppleStuff)       "/>
         <Message Importance="high" Text="IsForMacCatalyst :       $(IsForMacCatalyst)      "/>
-        <Message Importance="High" Text="                                                  "/>
-        <Message Importance="high" Text="iOSMode :                $(iOSMode)               "/>
     </Target>
 
     <!-- ==================== MAUI for .NET8 changes ==================== -->

--- a/Laerdal.Scripts/Laerdal.Builder.targets
+++ b/Laerdal.Scripts/Laerdal.Builder.targets
@@ -86,10 +86,6 @@
         
         <!-- RUN -->
         <MSBuild Projects="$(Laerdal_Project)" Properties="$(_Laerdal_Build_Parameters)" Targets="Restore;Build"/>
-        
-        <!-- special builds for the ios-simulators -->
-        <MSBuild Projects="$(Laerdal_Project)" Properties="$(_Laerdal_Build_Parameters);iOSMode=simulator-x64" Targets="Restore;Build"/>
-        <MSBuild Projects="$(Laerdal_Project)" Properties="$(_Laerdal_Build_Parameters);iOSMode=simulator-arm64" Targets="Restore;Build"/>
     </Target>
 
     <!-- GITHUB RELEASE -->

--- a/Laerdal.Scripts/Laerdal.Builder.targets
+++ b/Laerdal.Scripts/Laerdal.Builder.targets
@@ -86,6 +86,10 @@
         
         <!-- RUN -->
         <MSBuild Projects="$(Laerdal_Project)" Properties="$(_Laerdal_Build_Parameters)" Targets="Restore;Build"/>
+        
+        <!-- special builds for the ios-simulators -->
+        <MSBuild Projects="$(Laerdal_Project)" Properties="$(_Laerdal_Build_Parameters);iOSMode=simulator-x64" Targets="Restore;Build"/>
+        <MSBuild Projects="$(Laerdal_Project)" Properties="$(_Laerdal_Build_Parameters);iOSMode=simulator-arm64" Targets="Restore;Build"/>
     </Target>
 
     <!-- GITHUB RELEASE -->


### PR DESCRIPTION
Side-tweak: Upgrade to ios/mac-catalyst sdks version 18.0 per MAN-470