### PR TITLE
ci: modernize pipeline to match the shared laerdal/github_actions toolkit

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -89,7 +89,7 @@ jobs:
           configuration: Release
           no-restore: true
           arguments: >
-            -p:Laerdal_Version_Full='${{ needs.version.outputs.version-full }}'
+            -p:Laerdal_Version_Full='${{ needs.version.outputs.version-core }}'
             -p:GeneratePackageOnBuild=true
             -p:PackageOutputPath='${{ env.PACKAGE_OUTPUT_PATH }}'
           show-summary: true
@@ -101,7 +101,7 @@ jobs:
           path: '${{ github.workspace }}/Laerdal.Dfu/Laerdal.Dfu.csproj'
           configuration: Release
           arguments: >
-            -p:Laerdal_Version_Full='${{ needs.version.outputs.version-full }}'
+            -p:Laerdal_Version_Full='${{ needs.version.outputs.version-core }}'
             -p:BuildOnlyDudNet8=true
             -p:SourceRoot='${{ github.workspace }}/Laerdal.Dfu/'
             -p:GeneratePackageOnBuild=true

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -7,9 +7,9 @@ run-name: >-
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
-    branches: ['**']
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -17,8 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  packages: write
+  contents: write   # Needed to create tags and releases
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: '1'
@@ -27,25 +26,34 @@ env:
   SOLUTION_PATH: 'Laerdal.Dfu.Packages.slnx'
   PACKAGE_OUTPUT_PATH: '${{ github.workspace }}/Artifacts'
 
-  # version.json defines major + minor; build number auto-increments from GITHUB_RUN_NUMBER.
-  # The +8 offset carries over the count from the Azure DevOps migration.
-  LAERDAL_VERSION_MAJOR: 1
-  LAERDAL_VERSION_MINOR: 27
-
 jobs:
+
+  version:
+    uses: laerdal/github_actions/.github/workflows/reusable-version.yml@main
+    with:
+      config-file: './.config/version.json'
+      output-txt: 'output/version/version.txt'
+      output-json: 'output/version/version.json'
+      output-props: 'output/version/version.props'
+      artifact-name: 'version'
+      show-summary: true
 
   build:
     name: '🏗 Build & Pack'
-    runs-on: macos-14        # macOS required for net10.0-ios and net10.0-maccatalyst targets
+    runs-on: macos-14        # macOS required for net10.0-ios and net10.0-maccatalyst native binding compilation
     timeout-minutes: 30
+    needs: version
 
     steps:
 
       - name: '🔽 Checkout'
         uses: actions/checkout@v4
+
+      - name: '⬇️ Download Version artifact'
+        uses: actions/download-artifact@v8
         with:
-          fetch-tags: true
-          fetch-depth: 0
+          name: version
+          path: '${{ github.workspace }}/Output/Version'
 
       - name: '🔧 Setup .NET'
         uses: actions/setup-dotnet@v4
@@ -60,34 +68,60 @@ jobs:
           distribution: 'temurin'
 
       - name: '📲 Restore .NET workloads'
-        run: dotnet workload restore '${{ github.workspace }}/${{ env.SOLUTION_PATH }}'
+        uses: laerdal/github_actions/dotnet@main
+        with:
+          command: workload
+          arguments: restore '${{ github.workspace }}/${{ env.SOLUTION_PATH }}'
+          show-summary: true
 
       - name: '🔄 Restore'
-        run: dotnet restore '${{ github.workspace }}/${{ env.SOLUTION_PATH }}'
+        uses: laerdal/github_actions/dotnet@main
+        with:
+          command: restore
+          path: '${{ github.workspace }}/${{ env.SOLUTION_PATH }}'
+          show-summary: true
 
       - name: '🏗 Build & Pack'
-        run: |
-          VERSION_BUILD=$(( ${{ github.run_number }} + 8 ))
-          VERSION="${{ env.LAERDAL_VERSION_MAJOR }}.${{ env.LAERDAL_VERSION_MINOR }}.${VERSION_BUILD}"
-          echo "Version: ${VERSION}"
-          dotnet build '${{ github.workspace }}/${{ env.SOLUTION_PATH }}' \
-            --configuration Release \
-            --no-restore \
-            -p:Laerdal_Version_Full="${VERSION}" \
-            -p:GeneratePackageOnBuild=true \
+        uses: laerdal/github_actions/dotnet@main
+        with:
+          command: build
+          path: '${{ github.workspace }}/${{ env.SOLUTION_PATH }}'
+          configuration: Release
+          no-restore: true
+          arguments: >
+            -p:Laerdal_Version_Full='${{ needs.version.outputs.version-full }}'
+            -p:GeneratePackageOnBuild=true
             -p:PackageOutputPath='${{ env.PACKAGE_OUTPUT_PATH }}'
+          show-summary: true
 
       - name: '🏗 Build & Pack (force-dud — net10.0 only, no native bindings)'
-        run: |
-          VERSION_BUILD=$(( ${{ github.run_number }} + 8 ))
-          VERSION="${{ env.LAERDAL_VERSION_MAJOR }}.${{ env.LAERDAL_VERSION_MINOR }}.${VERSION_BUILD}"
-          dotnet build '${{ github.workspace }}/Laerdal.Dfu/Laerdal.Dfu.csproj' \
-            --configuration Release \
-            -p:Laerdal_Version_Full="${VERSION}" \
-            -p:BuildOnlyDudNet8=true \
-            -p:SourceRoot='${{ github.workspace }}/Laerdal.Dfu/' \
-            -p:GeneratePackageOnBuild=true \
+        uses: laerdal/github_actions/dotnet@main
+        with:
+          command: build
+          path: '${{ github.workspace }}/Laerdal.Dfu/Laerdal.Dfu.csproj'
+          configuration: Release
+          arguments: >
+            -p:Laerdal_Version_Full='${{ needs.version.outputs.version-full }}'
+            -p:BuildOnlyDudNet8=true
+            -p:SourceRoot='${{ github.workspace }}/Laerdal.Dfu/'
+            -p:GeneratePackageOnBuild=true
             -p:PackageOutputPath='${{ env.PACKAGE_OUTPUT_PATH }}'
+          show-summary: true
+
+      # SBOM is generated via the open-source CycloneDX .NET tool (no external service, no
+      # Laerdal-internal dependency tracker involved) and released as-is alongside the GitHub
+      # Release below. Signing it and feeding it into Laerdal's own SBOM/dependency-tracking
+      # system is a deliberate follow-up, not part of this pipeline.
+      - name: '📄 Generate CycloneDX SBOM'
+        uses: laerdal/github_actions/dotnet-cyclonedx@main
+        with:
+          path: '${{ github.workspace }}/${{ env.SOLUTION_PATH }}'
+          output: '${{ env.PACKAGE_OUTPUT_PATH }}'
+          filename: 'Laerdal.Dfu.cyclonedx.json'
+          output-format: 'Json'
+          set-name: 'Laerdal.Dfu'
+          set-version: '${{ needs.version.outputs.version-full }}'
+          show-summary: true
 
       - name: '⬆️ Upload Artifacts'
         uses: actions/upload-artifact@v4
@@ -96,28 +130,9 @@ jobs:
           path: '${{ env.PACKAGE_OUTPUT_PATH }}/**/*'
           if-no-files-found: error
 
-  publish-github:
-    name: '🚀 Publish to GitHub Packages'
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-
-      - name: '⬇️ Download Artifacts'
-        uses: actions/download-artifact@v4
-        with:
-          name: Artifacts
-          path: Artifacts
-
-      - name: '🚀 Push to GitHub Packages'
-        run: |
-          dotnet nuget push Artifacts/*.nupkg \
-            --source 'https://nuget.pkg.github.com/Laerdal/index.json' \
-            --api-key '${{ secrets.GITHUB_TOKEN }}'
-
   publish-nuget:
     name: '🚀 Publish to NuGet.org'
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: nuget-org
     runs-on: ubuntu-latest
@@ -131,7 +146,38 @@ jobs:
           path: Artifacts
 
       - name: '🚀 Push to NuGet.org'
-        run: |
-          dotnet nuget push Artifacts/*.nupkg \
-            --source 'https://api.nuget.org/v3/index.json' \
-            --api-key '${{ secrets.NUGET_ORG_FEED_API_KEY }}'
+        uses: laerdal/github_actions/dotnet-nuget-upload@main
+        with:
+          package-path: '${{ github.workspace }}/Artifacts/*.nupkg'
+          api-key: ${{ secrets.NUGET_ORG_FEED_API_KEY }}
+          source: 'https://api.nuget.org/v3/index.json'
+          show-summary: true
+
+  tag-and-release:
+    name: '🏷️ Tag & Release'
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [version, publish-nuget]
+    steps:
+
+      - name: '🔄 Checkout'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: '⬇️ Download Artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: Artifacts
+          path: Artifacts
+
+      - name: '🚀 Create GitHub Release'
+        uses: laerdal/github_actions/github-release@main
+        with:
+          tag: ${{ needs.version.outputs.version-fortag }}
+          title: 'Release ${{ needs.version.outputs.version-full }}'
+          generate-notes: 'true'
+          prerelease: ${{ needs.version.outputs.version-isprerelease }}
+          assets: 'Artifacts/Laerdal.Dfu.cyclonedx.json'
+          show-summary: 'true'


### PR DESCRIPTION
## Summary

Rebuilds this repo's CI/CD pipeline on the shared `laerdal/github_actions` toolkit that `Plugin.Bluetooth` and others already use, instead of raw `dotnet`/`dotnet nuget push` shell steps.

## Why

Side-by-side comparison against `Plugin.Bluetooth`'s `ci.yml` showed this pipeline predates the shared-toolkit adoption:
- No job-summary output anywhere (raw `run:` steps vs. the `dotnet@main` composite action's rich markdown summaries).
- Versioning is hand-rolled (`LAERDAL_VERSION_MAJOR/MINOR` env vars + `GITHUB_RUN_NUMBER + 8`), duplicated across two build steps, never produces a clean `x.y.0`, and ignores the `.config/version.json` file that's already sitting there with the right shape for the reusable versioning workflow.
- No release/tag history at all despite a `Laerdal.CreateNewReleaseInGithub.sh` script existing in `Laerdal.Scripts/` (now unreferenced by anything).
- Triggers on literally every branch push (`branches: ['**']`), unlike Bluetooth's `main`-only scope.
- Publishes to both GitHub Packages and NuGet.org.

## Changes

- **Versioning**: new `version` job via `laerdal/github_actions/.github/workflows/reusable-version.yml@main`, reading `.config/version.json` (`{major:1, minor:27}`), patch derived from git tags. Feeds `Laerdal_Version_Full` into both build steps (same MSBuild property the csproj already consumes - no csproj changes needed).
- **Build/restore steps**: switched to the `laerdal/github_actions/dotnet@main` composite action with `show-summary: true` throughout.
- **Publishing**: NuGet.org only (`laerdal/github_actions/dotnet-nuget-upload@main`) - dropped the GitHub Packages publish job entirely, per discussion (we don't need to host packages there, mainly wanted the Release).
- **New `tag-and-release` job**: creates a GitHub Release via `laerdal/github_actions/github-release@main`, tag/title/prerelease all derived from the version job's outputs - matches Bluetooth's pattern.
- **SBOM**: generates a CycloneDX SBOM (`laerdal/github_actions/dotnet-cyclonedx@main` - open-source .NET global tool, no Laerdal-internal service involved) and attaches it to each GitHub Release as-is. Signing it and feeding it into Laerdal's internal dependency-tracking system is a deliberate follow-up, not part of this PR.
- **Trigger scope**: narrowed to `main` only, matching the single-trunk model (no more `develop`).

## Versioning continuity

Pushed a `v1.27.200` tag (matching the last version actually published under the old scheme, `1.27.200` on NuGet.org) before this PR, so the new git-tag-based versioning continues at `1.27.201` on the next merge to `main` instead of resetting to `1.27.0`.

## Risk

Medium - this changes how every future version is built, versioned, and published. Mitigated by: the version-continuity seed tag above, and this PR's own `build` job (triggered by `pull_request`) exercising the full new build+SBOM path (not publish/tag, which are gated to pushes on `main`) before merge.

## Out of scope / follow-ups

- Deleting the now-unreferenced `Laerdal.Scripts/` shell scripts (`Laerdal.CreateNewReleaseInGithub.sh`, `Laerdal.GenerateSignAndUploadSbom.sh`, `Laerdal.SetupBuildEnvironment.sh`, `Laerdal.Version.sh`, plus `Laerdal.Builder.targets` which also turned out to be unreferenced by any csproj) - left in place, not part of this change.
- Deleting the `develop` branch (now a strict ancestor of `main`, safe to remove) - left for manual cleanup.
- Signing the SBOM and uploading it to Laerdal's internal SBOM/dependency-tracking system - explicitly deferred.