### PR TITLE
fix(android): stop pinning TargetPlatformVersion to 36.1

### DIFF
--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -40,8 +40,14 @@
 
     <!-- ==================== TARGET PLATFORM VERSION ======================= -->
     <PropertyGroup>
-        <!-- android    the TargetPlatformVersion must be aligned with the maxsdkversion used in androidmanifest.xml -->
-        <TargetPlatformVersion Condition="       '$(IsForAndroid)'      == 'true' ">36.1</TargetPlatformVersion>
+        <!-- android    deliberately NOT pinning TargetPlatformVersion here - it must float to whatever
+             the building SDK/workload resolves as default, same as every consumer (Laerdal.Bluetooth.Firmware,
+             fds-mobile-app, ...). A hardcoded value here (previously 36.1) can drift ahead of what consumers
+             resolve by default (e.g. 36.0), which makes this package's android-specific lib folder
+             (lib/net10.0-androidX.Y) invisible to those consumers under normal NuGet TargetPlatformVersion
+             compatibility rules - NuGet then silently falls back to the platform-agnostic lib/net10.0 folder,
+             which is a deliberate NotImplementedException stub. See reference_laerdal_dfu_android_packaging_bug
+             memory for the full incident writeup (discovered 2026-08-03, first real Android DFU test). -->
         <TargetPlatformMinVersion Condition="    '$(IsForAndroid)'      == 'true' ">21.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="  '$(IsForAndroid)'      == 'true' ">21.0</SupportedOSPlatformVersion>
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded `TargetPlatformVersion=36.1` override for android, letting it float to the SDK default (currently `36.0`) - matching every real consumer (`Laerdal.Bluetooth.Firmware`, `fds-mobile-app`), which don't pin one.
- Previously, the package's android assets were packed under `lib/net10.0-android36.1`, invisible to any consumer resolving `36.0` under NuGet's TargetPlatformVersion compatibility rules. NuGet silently fell back to `lib/net10.0` - the deliberate `NotImplementedException` stub meant for non-mobile platforms - with no build warning or error.
- Net effect: every real Android DFU attempt against the published package (1.27.201 and presumably earlier) has been throwing `NotImplementedException` from `DfuInstallation`'s constructor. This went undetected until the first real Android DFU run against `NordicDfuFirmwareInstallerForLittle` on 2026-08-03 - all earlier Android testing only exercised compile-time or non-DFU-transfer code paths.

## Test plan
- [x] `dotnet build -f net10.0-android -getProperty:TargetPlatformVersion` now returns `36.0`
- [x] Full multi-target build + local pack succeeds; unpacked `.nupkg` confirms android assets now live under `lib/net10.0-android36.0/`
- [x] Decompiled the packed android DLL (`ilspycmd`) and confirmed `DfuInstallation`'s constructor is the real Android implementation, not the `net10.0` stub
- [ ] End-to-end: re-run the Little DFU Dev Mode test in `fds-mobile-app` against the next published version to confirm the real fix on hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)