### PR TITLE
docs: cross-reference Laerdal.Dfu.Bindings.Android's TargetPlatformVersion risk

### DIFF
--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -47,7 +47,14 @@
              (lib/net10.0-androidX.Y) invisible to those consumers under normal NuGet TargetPlatformVersion
              compatibility rules - NuGet then silently falls back to the platform-agnostic lib/net10.0 folder,
              which is a deliberate NotImplementedException stub. See reference_laerdal_dfu_android_packaging_bug
-             memory for the full incident writeup (discovered 2026-08-03, first real Android DFU test). -->
+             memory for the full incident writeup (discovered 2026-08-03, first real Android DFU test).
+
+             The identical risk exists one level further down: Laerdal.Dfu.Bindings.Android (referenced
+             below as a PackageReference) hardcodes its own TargetPlatformVersion (currently 36, not
+             floating) rather than applying this same fix - see that repo's README "Known issues" section.
+             It hasn't bitten yet because its pin still happens to be <= what this project resolves to by
+             default, but that's coincidence, not a guarantee - re-check both sides whenever either one's
+             TargetPlatformVersion changes. -->
         <TargetPlatformMinVersion Condition="    '$(IsForAndroid)'      == 'true' ">21.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="  '$(IsForAndroid)'      == 'true' ">21.0</SupportedOSPlatformVersion>
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ installed locally; CI builds and publishes all targets on every push to `main`/`
   </PackageReference>
   ```
 
+- [`Laerdal.Dfu.Bindings.Android`](https://github.com/Laerdal/Laerdal.Dfu.Bindings.Android) (a
+  dependency of this package) hardcodes its own Android `TargetPlatformVersion` rather than
+  floating it the way this project does — see that repo's own README "Known issues" for why that's
+  a latent risk, not yet a live one. If an Android DFU build ever starts silently misbehaving after
+  bumping either project's `TargetPlatformVersion`, check there first.
+
 ## License
 
 [BSD 3-Clause](LICENSE)


### PR DESCRIPTION
## Summary

Docs-only, no code change. While solidifying `Laerdal.Dfu.Bindings.Android`'s repo hygiene, found that it hardcodes its own Android `TargetPlatformVersion` (36) instead of floating it the way this project's own csproj deliberately does (see the existing comment there, and `reference_laerdal_dfu_android_packaging_bug` for the original incident this project already hit).

It's not currently broken - the Bindings.Android pin happens to resolve `<=` what this project's consumers default to - but that's coincidence, not a guarantee, and the failure mode is silent (no build warning, just a `NotImplementedException` stub shipped instead of the real binding). Adds a cross-reference comment in `Laerdal.Dfu.csproj` and a README "Known issues" bullet so whoever next touches either project's `TargetPlatformVersion` checks the other side first.

## Why

Cross-repo landmine found during unrelated CI/README work on `Laerdal.Dfu.Bindings.Android` (see that repo's PR #14). Not fixing it now - no active breakage - just making sure it's not lost.

## Test plan

- [x] Docs-only change, no build/CI impact.