### PR TITLE
build: bump Laerdal.Dfu.Bindings.Android pin to 2.11.0.43910

### DIFF
--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -110,7 +110,7 @@
     <!-- =========================== PACKAGES ============================ -->
     <!-- Android -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
-        <PackageReference Include="Laerdal.Dfu.Bindings.Android" Version="2.9.0.43908" />
+        <PackageReference Include="Laerdal.Dfu.Bindings.Android" Version="2.11.0.43910" />
     </ItemGroup>
     <!-- iOS -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">


### PR DESCRIPTION
## Summary

Deliberate bump of the `Laerdal.Dfu.Bindings.Android` pin from `2.9.0.43908` to `2.11.0.43910`, following that repo's CI modernization and Nordic library bump (see [Laerdal.Dfu.Bindings.Android PR #14](https://github.com/Laerdal/Laerdal.Dfu.Bindings.Android/pull/14) and [#20](https://github.com/Laerdal/Laerdal.Dfu.Bindings.Android/pull/20)).

This is a bigger jump than the version numbers alone suggest: `2.9.0.43908` was itself still built against `net8.0-android34` (the `net10.0-android36` bump from PR #13 back in May never actually got published, because that repo's CI was broken until recently). Doing this deliberately now, not waiting for Dependabot to do it as a surprise across both a Nordic-version and a framework-target jump at once.

## Test plan

- [x] Confirmed locally that `net10.0-android` resolves to `36.0` here (`dotnet build -getProperty:TargetPlatformVersion`) — compatible with the new package's `36.0` pin, so this doesn't reproduce the packaging bug documented in this repo's own `TargetPlatformVersion` comment.
- [x] `dotnet restore` + `dotnet build -f net10.0-android` succeeds.
- [x] Decompiled the built `Laerdal.Dfu.dll` — `DfuInstallation` uses the real `DfuServiceInitiator`/`DfuServiceController` binding, not the `NotImplementedException` dud.