### PR TITLE
build: bump Laerdal.Dfu.Bindings.iOS/.MacCatalyst pin to 4.17.0.44005

### DIFF
--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -121,12 +121,12 @@
     </ItemGroup>
     <!-- iOS -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
-      <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.16.0.44003" />
+      <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.17.0.44005" />
       <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
     </ItemGroup>
     <!-- MacCatalyst -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">
-      <PackageReference Include="Laerdal.Dfu.Bindings.MacCatalyst" Version="4.16.0.44003" />
+      <PackageReference Include="Laerdal.Dfu.Bindings.MacCatalyst" Version="4.17.0.44005" />
       <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
     </ItemGroup>
     <!-- =========================== PACKAGES ============================ -->


### PR DESCRIPTION
## Summary
- Bumps the `Laerdal.Dfu.Bindings.iOS` and `Laerdal.Dfu.Bindings.MacCatalyst` PackageReference pins from `4.16.0.44003` to `4.17.0.44005`, consuming the Nordic iOS-DFU-Library 4.17.0 wrap merged in `Laerdal.Dfu.Bindings.iOS` PR #46.
- Mirrors the pattern already used for the Android side in PR #97 (Nordic 2.11.0).
- `Laerdal.Dfu`'s own `DFUState` usage (`DfuServiceDelegate.cs`) just passes through the binding's enum type rather than mirroring raw values, so no additional fix is needed here for the raw-value-shift risk noted in the bindings repo's README.

## Test plan
- [ ] CI build/pack succeeds for iOS and MacCatalyst targets