### PR TITLE
fix: bump Microsoft.NET.ILLink.Tasks to 10.0.11 for iOS/MacCatalyst

### DIFF
--- a/Laerdal.Dfu/Laerdal.Dfu.csproj
+++ b/Laerdal.Dfu/Laerdal.Dfu.csproj
@@ -122,12 +122,12 @@
     <!-- iOS -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
       <PackageReference Include="Laerdal.Dfu.Bindings.iOS" Version="4.17.0.44005" />
-      <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
+      <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.11" />
     </ItemGroup>
     <!-- MacCatalyst -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">
       <PackageReference Include="Laerdal.Dfu.Bindings.MacCatalyst" Version="4.17.0.44005" />
-      <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.0" />
+      <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.11" />
     </ItemGroup>
     <!-- =========================== PACKAGES ============================ -->
 


### PR DESCRIPTION
## Summary
- Fixes the main build break introduced by #103: `Laerdal.Dfu.Bindings.iOS 4.17.0.44005` requires `Microsoft.NET.ILLink.Tasks >= 10.0.11` transitively, but `Laerdal.Dfu.csproj` still pinned it at `10.0.0` for both iOS and MacCatalyst, producing `NU1605` (package downgrade, warning-as-error).
- Bumps both pins to `10.0.11` to match the floor.

## Test plan
- [ ] CI build/pack succeeds for iOS and MacCatalyst targets