### PR TITLE
ci: group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -22,3 +25,6 @@ updates:
       nuget:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      nuget:
+        patterns:
+          - "*"


### PR DESCRIPTION
Groups `github-actions` and `nuget` updates each under a wildcard group so routine bumps land as one PR per ecosystem instead of one per package.